### PR TITLE
feat(playback): configurable next-track preload

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,8 @@ if (localPropertiesFile.exists()) {
 }
 
 val baseApplicationId = "com.metrofuse.plus"
-val metroFuseVersionCode = 705
-val metroFuseVersionName = "7.0.5"
+val metroFuseVersionCode = 706
+val metroFuseVersionName = "7.0.6"
 val metroFuseUpdateRepository = "caduHD4/MetroFusePlus"
 val discordRpcApplicationId = "1508739806186963045"
 val applicationIdOverride = System.getenv("METROLIST_APPLICATION_ID")?.takeIf { it.isNotBlank() }

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -324,6 +324,7 @@ val PreventDuplicateTracksInQueueKey = booleanPreferencesKey("preventDuplicateTr
 val CrossfadeEnabledKey = booleanPreferencesKey("crossfadeEnabled")
 val CrossfadeDurationKey = floatPreferencesKey("crossfadeDurationFloat")
 val CrossfadeGaplessKey = booleanPreferencesKey("crossfadeGapless")
+val NextTrackPreloadCountKey = intPreferencesKey("nextTrackPreloadCount")
 val MetroMixEnabledKey = booleanPreferencesKey("metroMixEnabled")
 val MetroMixPresetKey = stringPreferencesKey("metroMixPreset")
 val MetroMixBarsKey = intPreferencesKey("metroMixBars")

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -4879,20 +4879,21 @@ class MusicService :
                     .Factory()
                     .setCache(playerCache)
                     .setUpstreamDataSourceFactory(
-                        DefaultDataSource.Factory(
-                            this,
-                            OkHttpDataSource.Factory(
-                                OkHttpClient
-                                    .Builder()
-                                    .proxy(YouTube.proxy)
-                                    .proxyAuthenticator { _, response ->
+                        DeezerAudioAwareDataSourceFactory(
+                            DefaultDataSource.Factory(
+                                this,
+                                OkHttpDataSource.Factory(
+                                    OkHttpClient
+                                        .Builder()
+                                        .proxy(YouTube.proxy)
+                                        .proxyAuthenticator { _, response ->
                                         YouTube.proxyAuth?.let { auth ->
                                             response.request
                                                 .newBuilder()
                                                 .header("Proxy-Authorization", auth)
                                                 .build()
                                         } ?: response.request
-                                    }.addInterceptor { chain ->
+                                        }.addInterceptor { chain ->
                                         var request = chain.request()
                                         if (request.url.queryParameter(YouTubeAudioProvider.STREAM_MARKER_QUERY) != null) {
                                             val clientName = request.url.queryParameter(YouTubeAudioProvider.STREAM_MARKER_QUERY)
@@ -4968,7 +4969,8 @@ class MusicService :
                                             request = builder.build()
                                         }
                                         chain.proceed(request)
-                                    }.build(),
+                                        }.build(),
+                                ),
                             ),
                         ),
                     ),
@@ -5208,9 +5210,7 @@ class MusicService :
         val resolvingFactory =
             ResolvingDataSource.Factory(
                 AmazonFfmpegAwareDataSourceFactory(
-                    DeezerAudioAwareDataSourceFactory(
-                        createCacheDataSource(),
-                    ),
+                    createCacheDataSource(),
                 ),
             ) { dataSpec ->
                 val explicitProviderMediaId =
@@ -5657,7 +5657,7 @@ class MusicService :
             resolved.cacheKey,
         )
         val startedAt = System.nanoTime()
-        val dataSource = DeezerAudioAwareDataSourceFactory(createCacheDataSource()).createDataSource()
+        val dataSource = createCacheDataSource().createDataSource()
         var readBytes = 0L
         try {
             dataSource.open(
@@ -5736,6 +5736,7 @@ class MusicService :
         return drmLicenseUri.isNullOrBlank() &&
             tempFilePath.isNullOrBlank() &&
             !cacheKey.startsWith(AMAZON_FALLBACK_CACHE_PREFIX) &&
+            parsedUri.getQueryParameter(SoundCloudAudioProvider.STREAM_HLS_MARKER_QUERY) != "1" &&
             mimeType != MimeTypes.APPLICATION_MPD &&
             mimeType != MimeTypes.APPLICATION_M3U8 &&
             !path.endsWith(".mpd") &&

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -187,6 +187,7 @@ import com.metrolist.music.constants.MetroMixPreset
 import com.metrolist.music.constants.MetroMixPresetKey
 import com.metrolist.music.constants.MetroMixVolumeCurve
 import com.metrolist.music.constants.MetroMixVolumeCurveKey
+import com.metrolist.music.constants.NextTrackPreloadCountKey
 import com.metrolist.music.constants.MediaSessionConstants
 import com.metrolist.music.constants.MediaSessionConstants.CommandAddToTargetPlaylist
 import com.metrolist.music.constants.MediaSessionConstants.CommandToggleLike
@@ -636,6 +637,7 @@ class MusicService :
 
     lateinit var player: ExoPlayer
         private set
+    private var nextTrackPreloadCoordinator: NextTrackPreloadCoordinator? = null
     private var secondaryPlayer: ExoPlayer? = null
     private var fadingPlayer: ExoPlayer? = null
     private var isCrossfading = false
@@ -1022,6 +1024,20 @@ class MusicService :
 
         connectivityManager = getSystemService()!!
         connectivityObserver = NetworkConnectivityObserver(this)
+        nextTrackPreloadCoordinator =
+            NextTrackPreloadCoordinator(
+                parentScope = scope,
+                player = player,
+                canPreload = {
+                    isNetworkConnected.value &&
+                        player.isPlaying &&
+                        dataStore.get(EnableSongCacheKey, true)
+                },
+                isPreparedElsewhere = { mediaId ->
+                    secondaryPlayer?.currentMediaItem?.mediaId == mediaId
+                },
+                preload = ::preloadNextTrack,
+            )
 
         val screenStateFilter =
             IntentFilter().apply {
@@ -1120,6 +1136,7 @@ class MusicService :
         scope.launch {
             connectivityObserver.networkStatus.collect { isConnected ->
                 isNetworkConnected.value = isConnected
+                nextTrackPreloadCoordinator?.requestRefresh()
                 if (isConnected && waitingForNetworkConnection.value) {
                     triggerRetry()
                 }
@@ -1129,6 +1146,52 @@ class MusicService :
                     }
                 }
             }
+        }
+
+        var lastPreloadSelectionSignature: Int? = null
+        scope.launch {
+            dataStore.data
+                .map { prefs ->
+                    val selectionSignature =
+                        listOf(
+                            prefs[AudioQualityKey],
+                            prefs[TidalAudioQualityKey],
+                            prefs[TidalResolverEndpointsKey],
+                            prefs[DeezerAudioQualityKey],
+                            prefs[DeezerResolverUrlKey],
+                            prefs[DeezerFastModeKey],
+                            prefs[DeezerProxyModeKey],
+                            prefs[DeezerProxyUrlKey],
+                            prefs[SoundCloudAudioQualityKey],
+                            prefs[SoundCloudAuthTokenKey],
+                            prefs[AppleAudioQualityKey],
+                            prefs[AmazonAudioQualityKey],
+                            prefs[QobuzBackendKey],
+                            prefs[QobuzCountryKey],
+                            prefs[AudioProviderOrderKey],
+                            prefs[AudioProviderMatchOverridesKey],
+                            prefs[InstagramCookieKey],
+                            prefs[InstagramUserAgentKey],
+                            prefs[InstagramAppIdKey],
+                            prefs[InstagramUuidKey],
+                            prefs[ProxyEnabledKey],
+                            prefs[StopOnProviderErrorKey],
+                        ).hashCode()
+                    (prefs[NextTrackPreloadCountKey] ?: NextTrackPreloadPolicy.DEFAULT_COUNT) to selectionSignature
+                }.distinctUntilChanged()
+                .collect { (count, selectionSignature) ->
+                    val coordinator = nextTrackPreloadCoordinator ?: return@collect
+                    if (
+                        lastPreloadSelectionSignature != null &&
+                        lastPreloadSelectionSignature != selectionSignature
+                    ) {
+                        cleanupSecondaryCrossfadePlayer(scheduleNext = false)
+                        coordinator.invalidateSelection().forEach(::invalidateResolvedProviderStream)
+                    }
+                    lastPreloadSelectionSignature = selectionSignature
+                    coordinator.updateCount(count)
+                    coordinator.requestRefresh()
+                }
         }
 
         // Watch for audio quality setting changes
@@ -4089,6 +4152,7 @@ class MusicService :
         QobuzAudioProvider.invalidate(mediaId)
         TidalAudioProvider.invalidate(mediaId)
         DeezerAudioProvider.invalidate(mediaId)
+        AmazonAudioProvider.invalidate(mediaId)
         SoundCloudAudioProvider.invalidate(mediaId)
         InstagramAudioProvider.invalidate(mediaId)
         YouTubeAudioProvider.invalidate(mediaId)
@@ -5252,7 +5316,7 @@ class MusicService :
                             .build()
                     }
                 } ?: run {
-                    clearResolvedStreamCache(mediaId)
+                    songUrlCache.remove(mediaId)
                 }
 
                 val queuedMetadataForDatabase = queuedMetadataForPlaybackDatabase(mediaId, song)
@@ -5495,6 +5559,215 @@ class MusicService :
         }
     }
 
+    private suspend fun preloadNextTrack(target: NextTrackPreloadTarget) {
+        val mediaItem = target.mediaItem
+        val mediaId = mediaItem.mediaIdForPlaybackSource() ?: return
+        val queuedMetadata = mediaItem.metadata
+        if (
+            mediaId.isBlank() ||
+            queuedMetadata?.isEpisode == true ||
+            queuedMetadata?.isVideoSong == true ||
+            mediaId.isLocalMediaId()
+        ) {
+            return
+        }
+
+        val song = database.getSongByIdBlocking(mediaId)
+        if (song?.song?.isLocal == true || song?.song?.isEpisode == true) return
+
+        val selectionKey = currentStreamSelectionKey()
+        val now = System.currentTimeMillis()
+        val cachedResolution = songUrlCache[mediaId]?.takeIf {
+            it.expiresAtMs > now + PRELOAD_MIN_URL_LIFETIME_MS &&
+                it.selectionKey == selectionKey
+        }
+
+        cachedResolution?.let { cached ->
+            val targetBytes = NextTrackPreloadPolicy.targetBytes(
+                queueDistance = target.queueDistance,
+                bitrate = cached.format.bitrate,
+                contentLength = cached.format.contentLength,
+            )
+            val cachedBytes = contiguousCachedPrefix(cached.cacheKey, targetBytes)
+            if (cachedBytes >= targetBytes) {
+                Timber.tag(PRELOAD_TAG).d(
+                    "Cache hit: mediaId=%s distance=%d cached=%d target=%d cacheKey=%s",
+                    mediaId,
+                    target.queueDistance,
+                    cachedBytes,
+                    targetBytes,
+                    cached.cacheKey,
+                )
+                return
+            }
+        }
+
+        val resolved = cachedResolution?.toPlaybackStreamResolution() ?: run {
+            songUrlCache.remove(mediaId)
+            val resolution = resolveOnlineStream(
+                mediaId = mediaId,
+                song = song,
+                queuedMetadata = queuedMetadata,
+                allowUserFeedback = false,
+            )
+            database.query {
+                queuedMetadataForPlaybackDatabase(mediaId, song)?.let { insert(it) }
+                upsert(resolution.format)
+            }
+            songUrlCache[mediaId] = resolution.toCachedSongStream(selectionKey)
+            resolution
+        }
+
+        if (!resolved.supportsProgressivePreload()) {
+            Timber.tag(PRELOAD_TAG).d(
+                "Skipped unsupported stream: mediaId=%s mime=%s cacheKey=%s",
+                mediaId,
+                resolved.mimeType,
+                resolved.cacheKey,
+            )
+            return
+        }
+
+        val targetBytes = NextTrackPreloadPolicy.targetBytes(
+            queueDistance = target.queueDistance,
+            bitrate = resolved.format.bitrate,
+            contentLength = resolved.format.contentLength,
+        )
+        val cachedBefore = contiguousCachedPrefix(resolved.cacheKey, targetBytes)
+        val missingRange = NextTrackPreloadPolicy.missingRange(cachedBefore, targetBytes)
+        if (missingRange == null) {
+            Timber.tag(PRELOAD_TAG).d(
+                "Cache hit: mediaId=%s distance=%d cached=%d target=%d cacheKey=%s",
+                mediaId,
+                target.queueDistance,
+                cachedBefore,
+                targetBytes,
+                resolved.cacheKey,
+            )
+            return
+        }
+
+        Timber.tag(PRELOAD_TAG).d(
+            "Starting: mediaId=%s distance=%d target=%d cachedBefore=%d provider=%s cacheKey=%s",
+            mediaId,
+            target.queueDistance,
+            targetBytes,
+            cachedBefore,
+            resolved.providerLabel(),
+            resolved.cacheKey,
+        )
+        val startedAt = System.nanoTime()
+        val dataSource = DeezerAudioAwareDataSourceFactory(createCacheDataSource()).createDataSource()
+        var readBytes = 0L
+        try {
+            dataSource.open(
+                DataSpec.Builder()
+                    .setUri(resolved.uri)
+                    .setKey(resolved.cacheKey)
+                    .setPosition(missingRange.position)
+                    .setLength(missingRange.length)
+                    .build(),
+            )
+            val buffer = ByteArray(PRELOAD_READ_BUFFER_BYTES)
+            while (readBytes < missingRange.length && coroutineContext.isActive) {
+                val requested = minOf(buffer.size.toLong(), missingRange.length - readBytes).toInt()
+                val read = dataSource.read(buffer, 0, requested)
+                if (read == C.RESULT_END_OF_INPUT) break
+                if (read <= 0) break
+                readBytes += read
+            }
+            if (!coroutineContext.isActive) throw CancellationException("Preload cancelled")
+        } finally {
+            runCatching(dataSource::close)
+        }
+
+        val cachedAfter = contiguousCachedPrefix(resolved.cacheKey, targetBytes)
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+        Timber.tag(PRELOAD_TAG).d(
+            "Completed: mediaId=%s cachedBefore=%d cachedAfter=%d downloaded=%d elapsedMs=%d provider=%s cacheKey=%s",
+            mediaId,
+            cachedBefore,
+            cachedAfter,
+            (cachedAfter - cachedBefore).coerceAtLeast(readBytes.coerceAtMost(missingRange.length)),
+            elapsedMs,
+            resolved.providerLabel(),
+            resolved.cacheKey,
+        )
+    }
+
+    private fun contiguousCachedPrefix(
+        cacheKey: String,
+        targetBytes: Long,
+    ): Long {
+        if (targetBytes <= 0) return 0L
+        val cachedLength = playerCache.getCachedLength(cacheKey, 0, targetBytes)
+        return cachedLength.takeIf { it > 0 }?.coerceAtMost(targetBytes) ?: 0L
+    }
+
+    private fun CachedSongStream.toPlaybackStreamResolution() =
+        PlaybackStreamResolution(
+            uri = uri,
+            expiresAtMs = expiresAtMs,
+            cacheKey = cacheKey,
+            format = format,
+            mimeType = mimeType,
+            drmLicenseUri = drmLicenseUri,
+            kid = kid,
+            decryptionKey = decryptionKey,
+        )
+
+    private fun PlaybackStreamResolution.toCachedSongStream(selectionKey: String) =
+        CachedSongStream(
+            uri = uri,
+            expiresAtMs = expiresAtMs,
+            cacheKey = cacheKey,
+            selectionKey = selectionKey,
+            format = format,
+            mimeType = mimeType,
+            drmLicenseUri = drmLicenseUri,
+            kid = kid,
+            decryptionKey = decryptionKey,
+        )
+
+    private fun PlaybackStreamResolution.supportsProgressivePreload(): Boolean {
+        val parsedUri = uri.toUri()
+        val scheme = parsedUri.scheme?.lowercase(Locale.US)
+        val path = parsedUri.path.orEmpty().lowercase(Locale.US)
+        return drmLicenseUri.isNullOrBlank() &&
+            tempFilePath.isNullOrBlank() &&
+            !cacheKey.startsWith(AMAZON_FALLBACK_CACHE_PREFIX) &&
+            mimeType != MimeTypes.APPLICATION_MPD &&
+            mimeType != MimeTypes.APPLICATION_M3U8 &&
+            !path.endsWith(".mpd") &&
+            !path.endsWith(".m3u8") &&
+            (scheme == "http" || scheme == "https" || DeezerAudioDataSource.isDeezerUri(parsedUri))
+    }
+
+    private fun PlaybackStreamResolution.providerLabel(): String =
+        when {
+            cacheKey.startsWith(QOBUZ_FALLBACK_CACHE_PREFIX) -> "qobuz"
+            isTidalFallbackCacheKey(cacheKey) -> "tidal"
+            cacheKey.startsWith(DEEZER_FALLBACK_CACHE_PREFIX) -> "deezer"
+            cacheKey.startsWith(SOUNDCLOUD_FALLBACK_CACHE_PREFIX) -> "soundcloud"
+            cacheKey.startsWith(INSTAGRAM_FALLBACK_CACHE_PREFIX) -> "instagram"
+            cacheKey.startsWith(APPLE_MUSIC_FALLBACK_CACHE_PREFIX) -> "apple"
+            cacheKey.startsWith(AMAZON_FALLBACK_CACHE_PREFIX) -> "amazon"
+            cacheKey.startsWith(YOUTUBE_FALLBACK_CACHE_PREFIX) -> "youtube"
+            cacheKey.startsWith(DIRECT_HTTP_AUDIO_CACHE_PREFIX) -> "direct"
+            else -> "unknown"
+        }
+
+    private fun invalidateResolvedProviderStream(mediaId: String) {
+        songUrlCache.remove(mediaId)
+        QobuzAudioProvider.invalidate(mediaId)
+        TidalAudioProvider.invalidate(mediaId)
+        DeezerAudioProvider.invalidate(mediaId)
+        AmazonAudioProvider.invalidate(mediaId)
+        SoundCloudAudioProvider.invalidate(mediaId)
+        InstagramAudioProvider.invalidate(mediaId)
+        YouTubeAudioProvider.invalidate(mediaId)
+    }
+
     private fun resolvePlaybackStreamBlocking(
         mediaId: String,
         song: Song?,
@@ -5537,6 +5810,7 @@ class MusicService :
         mediaId: String,
         song: Song?,
         queuedMetadata: com.metrolist.music.models.MediaMetadata? = null,
+        allowUserFeedback: Boolean = true,
     ): PlaybackStreamResolution {
         if (mediaId.toUri().isTidalPlaybackCdnUri()) {
             return PlaybackStreamResolution(
@@ -5647,7 +5921,9 @@ class MusicService :
         }
 
         fun showProviderWarning(message: String) {
-            showPlaybackToast(message)
+            if (allowUserFeedback) {
+                showPlaybackToast(message)
+            }
         }
 
         var soundCloudAttempt: Result<PlaybackStreamResolution> =
@@ -6634,7 +6910,7 @@ class MusicService :
                 kid = cached.kid,
                 decryptionKey = cached.decryptionKey
             )
-        } ?: clearResolvedStreamCache(mediaId)
+        } ?: songUrlCache.remove(mediaId)
 
         if (tidalPrimary) {
             mediaItem.buildPendingTidalRoute(
@@ -7745,6 +8021,8 @@ class MusicService :
     override fun onDestroy() {
         isRunning = false
         SpotifyCanvasClient.setListeningHistoryFailureReporter(null)
+        nextTrackPreloadCoordinator?.destroy()
+        nextTrackPreloadCoordinator = null
 
         if (!::player.isInitialized) {
             try {
@@ -8465,6 +8743,7 @@ class MusicService :
 
         secPlayer.prepare()
         secPlayer.playWhenReady = true
+        nextTrackPreloadCoordinator?.requestRefresh()
 
         crossfadePrepareJob =
             scope.launch {
@@ -8626,6 +8905,8 @@ class MusicService :
         fadingPlayer = currentPlayer
         player = nextPlayer
         secondaryPlayer = null
+        nextTrackPreloadCoordinator?.updatePlayer(player)
+        nextTrackPreloadCoordinator?.requestRefresh()
 
         fadingPlayer?.removeListener(this)
         fadingPlayer?.removeListener(sleepTimer)
@@ -8821,6 +9102,7 @@ class MusicService :
             }
         }
         secondaryPlayer = null
+        nextTrackPreloadCoordinator?.requestRefresh()
         isCrossfading = false
         activeMetroMixRuntimePreset = null
         activeMetroMixRuntimeProfile = null
@@ -8887,6 +9169,9 @@ class MusicService :
         private const val MIN_GAIN_MB = -2400 // Minimum gain in millibels (-24 dB)
 
         private const val TAG = "MusicService"
+        private const val PRELOAD_TAG = "NextTrackPreload"
+        private const val PRELOAD_MIN_URL_LIFETIME_MS = 60_000L
+        private const val PRELOAD_READ_BUFFER_BYTES = 64 * 1024
 
         // Was 4_000L — too short given the underlying OkHttpClient's own
         // 8s connect / 10s read timeouts, plus the token endpoint's cold-start

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -350,6 +350,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
@@ -5659,26 +5660,27 @@ class MusicService :
         val startedAt = System.nanoTime()
         val dataSource = createCacheDataSource().createDataSource()
         var readBytes = 0L
-        try {
-            dataSource.open(
-                DataSpec.Builder()
-                    .setUri(resolved.uri)
-                    .setKey(resolved.cacheKey)
-                    .setPosition(missingRange.position)
-                    .setLength(missingRange.length)
-                    .build(),
-            )
-            val buffer = ByteArray(PRELOAD_READ_BUFFER_BYTES)
-            while (readBytes < missingRange.length && coroutineContext.isActive) {
-                val requested = minOf(buffer.size.toLong(), missingRange.length - readBytes).toInt()
-                val read = dataSource.read(buffer, 0, requested)
-                if (read == C.RESULT_END_OF_INPUT) break
-                if (read <= 0) break
-                readBytes += read
+        runInterruptible(Dispatchers.IO) {
+            try {
+                dataSource.open(
+                    DataSpec.Builder()
+                        .setUri(resolved.uri)
+                        .setKey(resolved.cacheKey)
+                        .setPosition(missingRange.position)
+                        .setLength(missingRange.length)
+                        .build(),
+                )
+                val buffer = ByteArray(PRELOAD_READ_BUFFER_BYTES)
+                while (readBytes < missingRange.length && !Thread.currentThread().isInterrupted) {
+                    val requested = minOf(buffer.size.toLong(), missingRange.length - readBytes).toInt()
+                    val read = dataSource.read(buffer, 0, requested)
+                    if (read == C.RESULT_END_OF_INPUT) break
+                    if (read <= 0) break
+                    readBytes += read
+                }
+            } finally {
+                runCatching(dataSource::close)
             }
-            if (!coroutineContext.isActive) throw CancellationException("Preload cancelled")
-        } finally {
-            runCatching(dataSource::close)
         }
 
         val cachedAfter = contiguousCachedPrefix(resolved.cacheKey, targetBytes)

--- a/app/src/main/kotlin/com/metrolist/music/playback/NextTrackPreloadCoordinator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/NextTrackPreloadCoordinator.kt
@@ -1,0 +1,310 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import timber.log.Timber
+import kotlin.math.roundToLong
+
+internal data class NextTrackPreloadTarget(
+    val mediaItem: MediaItem,
+    val queueDistance: Int,
+)
+
+internal data class PreloadByteRange(
+    val position: Long,
+    val length: Long,
+)
+
+internal object NextTrackPreloadPolicy {
+    const val DEFAULT_COUNT = 3
+    const val MIN_COUNT = 0
+    const val MAX_COUNT = 10
+
+    private const val KIB = 1024L
+    private const val MIB = 1024L * KIB
+    private const val FALLBACK_BITRATE = 256_000L
+
+    fun targetBytes(
+        queueDistance: Int,
+        bitrate: Int,
+        contentLength: Long,
+    ): Long {
+        val seconds = when (queueDistance) {
+            1 -> 25L
+            2 -> 17L
+            else -> 10L
+        }
+        val maximum = when (queueDistance) {
+            1 -> 8L * MIB
+            2 -> 5L * MIB
+            else -> 3L * MIB
+        }
+        val estimatedBitrate = bitrate.takeIf { it > 0 }?.toLong() ?: FALLBACK_BITRATE
+        val estimatedBytes = (estimatedBitrate * seconds / 8.0).roundToLong()
+        val bounded = estimatedBytes.coerceIn(512L * KIB, maximum)
+        return contentLength.takeIf { it > 0 }?.let { bounded.coerceAtMost(it) } ?: bounded
+    }
+
+    fun missingRange(
+        cachedPrefixBytes: Long,
+        targetBytes: Long,
+    ): PreloadByteRange? {
+        val cached = cachedPrefixBytes.coerceAtLeast(0L)
+        val target = targetBytes.coerceAtLeast(0L)
+        if (target == 0L || cached >= target) return null
+        return PreloadByteRange(position = cached, length = target - cached)
+    }
+
+    fun <T> selectNext(
+        currentIndex: Int,
+        windowCount: Int,
+        preloadCount: Int,
+        repeatMode: Int,
+        itemAt: (Int) -> T,
+        idOf: (T) -> String,
+        nextIndex: (Int) -> Int,
+    ): List<Pair<Int, T>> {
+        val count = preloadCount.coerceIn(MIN_COUNT, MAX_COUNT)
+        if (
+            count == 0 ||
+            windowCount <= 1 ||
+            currentIndex !in 0 until windowCount ||
+            repeatMode == Player.REPEAT_MODE_ONE
+        ) {
+            return emptyList()
+        }
+
+        val selected = mutableListOf<Pair<Int, T>>()
+        val visitedIndices = mutableSetOf(currentIndex)
+        val selectedIds = mutableSetOf<String>()
+        var index = currentIndex
+        var distance = 0
+
+        while (selected.size < count && visitedIndices.size < windowCount) {
+            val candidateIndex = nextIndex(index)
+            if (candidateIndex == C.INDEX_UNSET || candidateIndex !in 0 until windowCount) break
+            if (!visitedIndices.add(candidateIndex)) break
+            index = candidateIndex
+            distance++
+
+            val item = itemAt(candidateIndex)
+            if (selectedIds.add(idOf(item))) {
+                selected += distance to item
+            }
+        }
+        return selected
+    }
+}
+
+internal data class PreloadWindowDiff(
+    val cancel: Set<String>,
+    val start: List<String>,
+)
+
+internal fun preloadWindowDiff(
+    active: Set<String>,
+    completed: Set<String>,
+    wantedInPriorityOrder: List<String>,
+): PreloadWindowDiff {
+    val wanted = wantedInPriorityOrder.toSet()
+    return PreloadWindowDiff(
+        cancel = active - wanted,
+        start = wantedInPriorityOrder.filterNot { it in active || it in completed },
+    )
+}
+
+internal suspend fun runBestEffortPreload(block: suspend () -> Unit): Result<Unit> =
+    try {
+        block()
+        Result.success(Unit)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        Result.failure(error)
+    }
+
+internal class NextTrackPreloadCoordinator(
+    parentScope: CoroutineScope,
+    private var player: Player,
+    private val canPreload: () -> Boolean,
+    private val isPreparedElsewhere: (String) -> Boolean,
+    private val preload: suspend (NextTrackPreloadTarget) -> Unit,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Player.Listener {
+    private val coordinatorJob = SupervisorJob(parentScope.coroutineContext[Job])
+    private val scope = CoroutineScope(parentScope.coroutineContext + coordinatorJob)
+    private val updates = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    private val semaphore = Semaphore(permits = 1)
+    private val activeJobs = linkedMapOf<String, Job>()
+    private val completedInWindow = mutableSetOf<String>()
+    private var preloadCount = NextTrackPreloadPolicy.DEFAULT_COUNT
+    private var lastWindowIds = emptyList<String>()
+
+    init {
+        player.addListener(this)
+        scope.launch {
+            updates.collectLatest {
+                delay(200)
+                refreshWindow(ioDispatcher)
+            }
+        }
+        requestRefresh()
+    }
+
+    fun updateCount(value: Int) {
+        val normalized = value.coerceIn(NextTrackPreloadPolicy.MIN_COUNT, NextTrackPreloadPolicy.MAX_COUNT)
+        if (preloadCount == normalized) return
+        preloadCount = normalized
+        requestRefresh()
+    }
+
+    fun requestRefresh() {
+        updates.tryEmit(Unit)
+    }
+
+    fun updatePlayer(newPlayer: Player) {
+        if (player === newPlayer) return
+        player.removeListener(this)
+        player = newPlayer
+        player.addListener(this)
+        activeJobs.values.forEach(Job::cancel)
+        activeJobs.clear()
+        completedInWindow.clear()
+        lastWindowIds = emptyList()
+        requestRefresh()
+    }
+
+    fun invalidateSelection(): Set<String> {
+        val affected = (lastWindowIds + activeJobs.keys + completedInWindow).toSet()
+        activeJobs.values.forEach(Job::cancel)
+        activeJobs.clear()
+        completedInWindow.clear()
+        requestRefresh()
+        return affected
+    }
+
+    fun destroy() {
+        player.removeListener(this)
+        coordinatorJob.cancel()
+        activeJobs.clear()
+        completedInWindow.clear()
+    }
+
+    override fun onEvents(
+        player: Player,
+        events: Player.Events,
+    ) {
+        if (
+            events.containsAny(
+                Player.EVENT_MEDIA_ITEM_TRANSITION,
+                Player.EVENT_TIMELINE_CHANGED,
+                Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED,
+                Player.EVENT_REPEAT_MODE_CHANGED,
+                Player.EVENT_IS_PLAYING_CHANGED,
+                Player.EVENT_PLAYBACK_STATE_CHANGED,
+            )
+        ) {
+            requestRefresh()
+        }
+    }
+
+    private fun refreshWindow(ioDispatcher: CoroutineDispatcher) {
+        val targets = if (canPreload()) queueWindow() else emptyList()
+        val allWindowIds = targets.map { it.mediaItem.mediaId }
+        if (allWindowIds != lastWindowIds) {
+            Timber.tag(TAG).d("Preload window: %s", allWindowIds.joinToString(","))
+            completedInWindow.retainAll(allWindowIds.toSet())
+            lastWindowIds = allWindowIds
+        }
+
+        val targetById = targets
+            .filterNot { isPreparedElsewhere(it.mediaItem.mediaId) }
+            .associateBy { it.mediaItem.mediaId }
+        val wantedIds = targets
+            .map { it.mediaItem.mediaId }
+            .filter { it in targetById }
+        val diff = preloadWindowDiff(activeJobs.keys, completedInWindow, wantedIds)
+
+        diff.cancel.forEach { mediaId ->
+            activeJobs.remove(mediaId)?.cancel()
+            Timber.tag(TAG).d("Cancelled: %s left preload window", mediaId)
+        }
+
+        diff.start.forEach { mediaId ->
+            val target = targetById.getValue(mediaId)
+            val job = scope.launch(ioDispatcher) {
+                val runningJob = coroutineContext[Job]
+                var completed = true
+                try {
+                    runBestEffortPreload {
+                        semaphore.withPermit {
+                            preload(target)
+                        }
+                    }.exceptionOrNull()?.let { error ->
+                        Timber.tag(TAG).w(error, "Failed: mediaId=%s distance=%d", mediaId, target.queueDistance)
+                    }
+                } catch (error: CancellationException) {
+                    completed = false
+                    Timber.tag(TAG).d("Cancelled: %s", mediaId)
+                    throw error
+                } finally {
+                    scope.launch(Dispatchers.Main.immediate) {
+                        if (activeJobs[mediaId] === runningJob) {
+                            activeJobs.remove(mediaId)
+                        }
+                        if (completed && mediaId in lastWindowIds) {
+                            completedInWindow += mediaId
+                        }
+                    }
+                }
+            }
+            activeJobs[mediaId] = job
+        }
+    }
+
+    private fun queueWindow(): List<NextTrackPreloadTarget> {
+        val timeline = player.currentTimeline
+        val currentIndex = player.currentMediaItemIndex
+        val window = Timeline.Window()
+        return NextTrackPreloadPolicy.selectNext(
+            currentIndex = currentIndex,
+            windowCount = timeline.windowCount,
+            preloadCount = preloadCount,
+            repeatMode = player.repeatMode,
+            itemAt = { index -> timeline.getWindow(index, window).mediaItem },
+            idOf = { it.mediaId },
+            nextIndex = { index ->
+                timeline.getNextWindowIndex(index, player.repeatMode, player.shuffleModeEnabled)
+            },
+        ).map { (distance, mediaItem) ->
+            NextTrackPreloadTarget(mediaItem = mediaItem, queueDistance = distance)
+        }
+    }
+
+    private companion object {
+        const val TAG = "NextTrackPreload"
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -399,7 +399,7 @@ fun PlayerSettings(
                             Text(stringResource(R.string.next_track_preload_desc))
                             Text(
                                 if (nextTrackPreloadCount == 0) {
-                                    stringResource(R.string.disabled)
+                                    stringResource(R.string.next_track_preload_disabled)
                                 } else {
                                     pluralStringResource(
                                         R.plurals.next_track_preload_count,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/PlayerSettings.kt
@@ -58,6 +58,7 @@ import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.constants.MetroMixEnabledKey
 import com.metrolist.music.constants.MetroMixPreset
 import com.metrolist.music.constants.MetroMixPresetKey
+import com.metrolist.music.constants.NextTrackPreloadCountKey
 import com.metrolist.music.constants.PauseOnMute
 import com.metrolist.music.constants.PersistentQueueKey
 import com.metrolist.music.constants.PersistentShuffleAcrossQueuesKey
@@ -123,6 +124,10 @@ fun PlayerSettings(
     val (crossfadeGapless, onCrossfadeGaplessChange) = rememberPreference(
         CrossfadeGaplessKey,
         defaultValue = true
+    )
+    val (nextTrackPreloadCount, onNextTrackPreloadCountChange) = rememberPreference(
+        NextTrackPreloadCountKey,
+        defaultValue = 3
     )
     val (metroMixEnabled, onMetroMixEnabledChange) = rememberPreference(
         MetroMixEnabledKey,
@@ -385,6 +390,34 @@ fun PlayerSettings(
                         )
                     },
                     onClick = { onStopOnProviderErrorChange(!stopOnProviderError) }
+                ))
+                add(Material3SettingsItem(
+                    icon = painterResource(R.drawable.cached),
+                    title = { Text(stringResource(R.string.next_track_preload)) },
+                    description = {
+                        Column {
+                            Text(stringResource(R.string.next_track_preload_desc))
+                            Text(
+                                if (nextTrackPreloadCount == 0) {
+                                    stringResource(R.string.disabled)
+                                } else {
+                                    pluralStringResource(
+                                        R.plurals.next_track_preload_count,
+                                        nextTrackPreloadCount,
+                                        nextTrackPreloadCount,
+                                    )
+                                }
+                            )
+                            Slider(
+                                value = nextTrackPreloadCount.toFloat(),
+                                onValueChange = {
+                                    onNextTrackPreloadCountChange(it.roundToInt().coerceIn(0, 10))
+                                },
+                                valueRange = 0f..10f,
+                                steps = 9,
+                            )
+                        }
+                    },
                 ))
                 add(Material3SettingsItem(
                     icon = painterResource(R.drawable.shuffle),

--- a/app/src/main/res/values-pt-rBR/metrolist_strings.xml
+++ b/app/src/main/res/values-pt-rBR/metrolist_strings.xml
@@ -825,6 +825,12 @@
     <string name="audio_quality_very_high">O mais alto possível</string>
     <string name="autoplay">Reprodução Automática</string>
     <string name="autoplay_desc">Reproduzir automaticamente a próxima música quando a atual terminar</string>
+    <string name="next_track_preload">Pré-carregar próximas músicas</string>
+    <string name="next_track_preload_desc">Armazena antecipadamente parte das próximas músicas da fila no cache para reduzir o tempo entre faixas.</string>
+    <plurals name="next_track_preload_count">
+        <item quantity="one">%d música</item>
+        <item quantity="other">%d músicas</item>
+    </plurals>
     <string name="system_equalizer_desc">Abrir o Equalizador nativo do Android</string>
     <string name="eq_wizard">AutoEQ Wizard</string>
     <string name="eq_download_db">Baixar banco de dados do AutoEQ (17 MB)</string>

--- a/app/src/main/res/values-pt-rBR/metrolist_strings.xml
+++ b/app/src/main/res/values-pt-rBR/metrolist_strings.xml
@@ -827,6 +827,7 @@
     <string name="autoplay_desc">Reproduzir automaticamente a próxima música quando a atual terminar</string>
     <string name="next_track_preload">Pré-carregar próximas músicas</string>
     <string name="next_track_preload_desc">Armazena antecipadamente parte das próximas músicas da fila no cache para reduzir o tempo entre faixas.</string>
+    <string name="next_track_preload_disabled">Desativado</string>
     <plurals name="next_track_preload_count">
         <item quantity="one">%d música</item>
         <item quantity="other">%d músicas</item>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -1328,6 +1328,7 @@
     <string name="audio_quality_very_high">Highest possible</string>
     <string name="next_track_preload">Preload next tracks</string>
     <string name="next_track_preload_desc">Stores part of the upcoming tracks in the cache ahead of time to reduce the delay between tracks.</string>
+    <string name="next_track_preload_disabled">Disabled</string>
     <plurals name="next_track_preload_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -1326,6 +1326,12 @@
 
     <!-- Player and Audio Settings -->
     <string name="audio_quality_very_high">Highest possible</string>
+    <string name="next_track_preload">Preload next tracks</string>
+    <string name="next_track_preload_desc">Stores part of the upcoming tracks in the cache ahead of time to reduce the delay between tracks.</string>
+    <plurals name="next_track_preload_count">
+        <item quantity="one">%d track</item>
+        <item quantity="other">%d tracks</item>
+    </plurals>
     <string name="autoplay">Autoplay</string>
     <string name="autoplay_desc">Automatically play the next song when the current one ends</string>
     <string name="apple_music_fallback">Apple Music fallback</string>

--- a/app/src/test/kotlin/com/metrolist/music/playback/NextTrackPreloadPolicyTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/NextTrackPreloadPolicyTest.kt
@@ -1,0 +1,160 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NextTrackPreloadPolicyTest {
+    @Test
+    fun `count zero disables the window`() {
+        assertTrue(select(count = 0).isEmpty())
+    }
+
+    @Test
+    fun `count one selects only the immediate next item`() {
+        assertEquals(listOf(1 to "B"), select(count = 1))
+    }
+
+    @Test
+    fun `count three selects three next items in order`() {
+        assertEquals(listOf(1 to "B", 2 to "C", 3 to "D"), select(count = 3))
+    }
+
+    @Test
+    fun `count ten is honored when the queue contains enough items`() {
+        val items = (0..11).map(Int::toString)
+        assertEquals(10, select(items = items, count = 10).size)
+    }
+
+    @Test
+    fun `end of queue without repeat produces no targets`() {
+        assertTrue(select(currentIndex = 4, count = 3).isEmpty())
+    }
+
+    @Test
+    fun `repeat one never preloads copies of the current item`() {
+        assertTrue(select(count = 3, repeatMode = Player.REPEAT_MODE_ONE).isEmpty())
+    }
+
+    @Test
+    fun `repeat all wraps without selecting the current item twice`() {
+        assertEquals(
+            listOf(1 to "A", 2 to "B", 3 to "C"),
+            select(currentIndex = 4, count = 3, repeatMode = Player.REPEAT_MODE_ALL),
+        )
+    }
+
+    @Test
+    fun `shuffle follows the timeline supplied next order`() {
+        val shuffledNext = mapOf(0 to 3, 3 to 1, 1 to 4, 4 to 2, 2 to C.INDEX_UNSET)
+        assertEquals(
+            listOf(1 to "D", 2 to "B", 3 to "E"),
+            select(count = 3, next = { shuffledNext[it] ?: C.INDEX_UNSET }),
+        )
+    }
+
+    @Test
+    fun `queue change cancels stale work and starts new priority order`() {
+        val diff = preloadWindowDiff(
+            active = setOf("B", "C", "D"),
+            completed = emptySet(),
+            wantedInPriorityOrder = listOf("G", "H", "I"),
+        )
+        assertEquals(setOf("B", "C", "D"), diff.cancel)
+        assertEquals(listOf("G", "H", "I"), diff.start)
+    }
+
+    @Test
+    fun `completed cache hit does not start redundant work`() {
+        val diff = preloadWindowDiff(
+            active = emptySet(),
+            completed = setOf("B"),
+            wantedInPriorityOrder = listOf("B", "C"),
+        )
+        assertEquals(listOf("C"), diff.start)
+    }
+
+    @Test
+    fun `cache hit has no missing range`() {
+        assertNull(NextTrackPreloadPolicy.missingRange(cachedPrefixBytes = 1_000, targetBytes = 1_000))
+    }
+
+    @Test
+    fun `partial cache starts at first missing byte`() {
+        assertEquals(
+            PreloadByteRange(position = 400, length = 600),
+            NextTrackPreloadPolicy.missingRange(cachedPrefixBytes = 400, targetBytes = 1_000),
+        )
+    }
+
+    @Test
+    fun `cache miss starts at zero`() {
+        assertEquals(
+            PreloadByteRange(position = 0, length = 1_000),
+            NextTrackPreloadPolicy.missingRange(cachedPrefixBytes = 0, targetBytes = 1_000),
+        )
+    }
+
+    @Test
+    fun `nearer tracks receive a larger adaptive byte target`() {
+        val first = NextTrackPreloadPolicy.targetBytes(1, bitrate = 320_000, contentLength = 0)
+        val second = NextTrackPreloadPolicy.targetBytes(2, bitrate = 320_000, contentLength = 0)
+        val third = NextTrackPreloadPolicy.targetBytes(3, bitrate = 320_000, contentLength = 0)
+        assertTrue(first > second)
+        assertTrue(second > third)
+    }
+
+    @Test
+    fun `quality invalidation makes completed items eligible again`() {
+        val before = preloadWindowDiff(emptySet(), setOf("B"), listOf("B"))
+        val after = preloadWindowDiff(emptySet(), emptySet(), listOf("B"))
+        assertTrue(before.start.isEmpty())
+        assertEquals(listOf("B"), after.start)
+    }
+
+    @Test
+    fun `provider failure is contained as best effort`() = runBlocking {
+        val failure = IllegalStateException("provider failed")
+        val result = runBestEffortPreload { throw failure }
+        assertSame(failure, result.exceptionOrNull())
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `cancellation is never swallowed`() = runBlocking {
+        runBestEffortPreload { throw CancellationException("left window") }
+    }
+
+    private fun select(
+        items: List<String> = listOf("A", "B", "C", "D", "E"),
+        currentIndex: Int = 0,
+        count: Int,
+        repeatMode: Int = Player.REPEAT_MODE_OFF,
+        next: ((Int) -> Int)? = null,
+    ): List<Pair<Int, String>> =
+        NextTrackPreloadPolicy.selectNext(
+            currentIndex = currentIndex,
+            windowCount = items.size,
+            preloadCount = count,
+            repeatMode = repeatMode,
+            itemAt = items::get,
+            idOf = { it },
+            nextIndex = next ?: { index ->
+                when {
+                    index + 1 < items.size -> index + 1
+                    repeatMode == Player.REPEAT_MODE_ALL -> 0
+                    else -> C.INDEX_UNSET
+                }
+            },
+        )
+}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+---v7.0.6
+# MetroFuse+ 7.0.6
+
+- Added configurable preloading for the next 0–10 queue tracks to reduce the delay between songs.
+- Reused the playback resolver and cache with adaptive preload sizes, queue-aware shuffle/repeat navigation, limited concurrency and cancellation of obsolete work.
+- Added safe handling for cache hits and partial cache entries while leaving unsupported adaptive, DRM and special-provider streams to normal playback.
+
 ---v7.0.5
 # MetroFuse+ 7.0.5
 


### PR DESCRIPTION
## Alterações

- adiciona configuração de preload das próximas 0–10 músicas;
- reutiliza o resolver e o `SimpleCache` do playback;
- acompanha shuffle, repeat e mudanças da fila;
- limita concorrência e cancela preloads obsoletos;
- trata cache hit, parcial e miss;
- adiciona testes unitários da política e do coordenador;
- atualiza a versão para 7.0.6 e adiciona o changelog.

## Motivação

Reduzir o atraso entre faixas preparando antecipadamente uma parte adaptativa das próximas músicas, sem alterar a fila ou interferir nos erros e retries do playback normal.

## Validação

- `git diff --check`: aprovado;
- erro de compilação referente a `R.string.disabled`: corrigido com recurso específico e fallback base;
- o workflow Android completo ainda precisa confirmar a compilação após essa correção.